### PR TITLE
fix: generalization of the role of the Issuer within the federation

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -225,7 +225,7 @@ an X.509 Certificate.
    3.2](https://openid.net/specs/openid-federation-1_0.html#name-trust-chain)
    of [OPENID-FED].
 
-3. The Trust Anchor and its Intermediates SHOULD implement an ACME server,
+3. The Issuer, be this the Trust Anchor or one or more of its Intermediates, MUST implement an ACME server,
    extended according to this document.
 
 4. The Requestor MUST publish the metadata type `acme_requestor` in its Entity


### PR DESCRIPTION
This PR clarifies that the Issuer MUST implement ACME and it might match the trust anchor or one of its intermediates