### PR TITLE
Fix Giuseppe's name in authors

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -24,6 +24,7 @@ venue:
 author:
  -
     fullname: Giuseppe De Marco
+    ins: G. De Marco
     organization: independent
     email: demarcog83@gmail.com
  -


### PR DESCRIPTION
Giuseppe's name is not handled correctly by heuristics. This explicitly sets the "initials/surname" field to fix that, copying from the OPENID-FED reference's authors.