### PR TITLE
Remove entity_identifier from challenge response

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -561,8 +561,6 @@ sig (required, string):  a base64url encoding of a JWT, signing the token
     [Requestor](#requestor-metadata). It is REQUIRED that this JWT include a `kid` claim
     corresponding to a valid key.
 
-entity_identifier (required, string):  the Entity identifier of the Requestor.
-
 trust_chain (optional, array of string):  an array of base64url-encoded bytes
     containing a signed JWT and representing the Trust Chain of the Requestor,
     See section 4.3 of [OPENID-FED]. The Requestor SHOULD use a Trust Anchor it
@@ -586,7 +584,6 @@ A non-normative example for an authorization with `trust_chain` specified:
      }),
      "payload": base64url({
       "sig": "wQAvHlPV1tVxRW0vZUa4BQ...",
-      "entity_identifier": "https://requestor.example.com",
       "trust_chain": ["eyJhbGciOiJFU...", "eyJhbGci..."]
      }),
      "signature": "Q1bURgJoEslbD1c5...3pYdSMLio57mQNN4"


### PR DESCRIPTION
As mentioned in #38, the entity identifier is implicitly known from the parent authorization of the challenge. Thus, it is not necessary to include the identifier in the challenge response.