### PR TITLE
CAA is irrelevant

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -463,7 +463,6 @@ the `acme_provider` metadata:
       "meta": {
         "termsOfService": "https://issuer.example.com/acme/terms/2017-5-30",
         "website": "https://www.issuer.example.com/",
-        "caaIdentities": ["issuer.example.com"],
         "externalAccountRequired": false
       }
     }


### PR DESCRIPTION
We can't check CAA for non-dnsName identifiers. While the Entity Configuration is marked non-normative, having CAA in there will be confusing.