### PR TITLE
Clarify construction of signed challenge

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -599,15 +599,17 @@ token (required, string):  A random value that uniquely identifies the
 
 The Requestor responds with an object with the following format:
 
-sig (required, string):  a base64url encoding of a JWT, signing the key
-    authorization encoded in UTF-8.
+sig (required, string):  the compact JSON serialization (as described in
+    {{Section 7.1 of !RFC7515}}) of a JWS, signing the key authorization
+    encoded in UTF-8.
     The key authorization is computed from the token in the challenge and the
     Requestor's ACME account key, as defined in {{Section 8.1 of !RFC8555}}.
     The signature must be made by one of the keys published in the Requestor's
     `acme_requestor` metadata in its Entity Configuration, as specified in
-    {{requestor-metadata}}. It is REQUIRED that this JWT include a `kid` claim
-    corresponding to a valid key.
-
+    {{requestor-metadata}}.
+    The JWS MUST include a `kid` header parameter corresponding to the key used
+    to sign the key authorization and a `typ` header parameter set to
+    "signed-acme-challenge+jwt".
 trust_chain (optional, array of string):  an array of base64url-encoded bytes
     containing a signed JWT and representing the Trust Chain of the Requestor,
     See {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}.


### PR DESCRIPTION
The existing text about how the ACME requestor should sign the ACME issuer's challenge token had several ambiguities and problems. This change is stacked on top of #53: the problems I am describing are orthogonal to that change. Below, I will reference text assuming #53 is merged.

> a base64url encoding of a JWT

- "a base64url encoding" isn't specific enough. It makes more sense to me to explicitly require JWS Compact Serialization here, which is consistent with the requirement in OpenID Federation ([1]).
- If this is a signature, then presumably what we are constructing is a JWS. A JWS is a JWT, so this wasn't wrong, but it seems more clear to explicitly say JWS, as otherwise it's unclear how the implementation should represent a signature.

> It is REQUIRED that this JWT include a `kid` claim corresponding to a valid key.

If I'm understanding all this correctly, then `sig` is a JWS whose payload is _not_ a JSON object (it's just the UTF-8 string of the keyauth), and thus it doesn't make sense to talk about a `kid` claim. Rather, there should be a `kid` Header Parameter in the JWS.

Finally, we should use a `typ` Header Parameter to avoid cross-JWT confusion, per RFC 8725 ([2]). I invented `signed-acme-challenge+jwt` but we can probably do better.

[1]: https://openid.net/specs/openid-federation-1_0-41.html#section-1.1
[2]: https://www.rfc-editor.org/rfc/rfc8725.html#section-3.11