### PR TITLE
Remove non-existent response from sequence diagram

### DIFF
--- a/diagrams/plantuml
+++ b/diagrams/plantuml
@@ -20,8 +20,6 @@ opt If requestor did not provide Trust Chain
   A <<->> F: Determine Trust Chain\nfrom Issuer's Trust Anchor to Requestor\n(OpenID Federation Discovery)
 end
 A ->> A: Evaluate trust chain
-A -->> RC: Respond to POST with validation success
-
 
 loop Poll until authz status is "valid" or "invalid"
 RC ->> A: POST-as-GET /acme/authz/[authz-id]

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -369,11 +369,6 @@ ACME account with the Issuer.
         |                  |                                 |    | Evaluate trust chain |
         |                  |                                 |<---'                      |
         |                  |                                 |                           |
-        |                  |  Respond to POST with           |                           |
-        |                  |  validation success             |                           |
-        |                  |<- - - - - - - - - - - - - - - - -                           |
-        |                  |                                 |                           |
-        |                  |                                 |                           |
         |  _________________________________________________________________________     |
         |  ! LOOP  /  Poll until authz status                |                      !    |
         |  !      /  is "valid" or "invalid"                 |                      !    |


### PR DESCRIPTION
The diagram shows the requestor POSTing to the challenge at L326, and then the issuer responds at L332 indicating validation has begun. The existing diagram also illustrates a response from issuer to requestor at L372, but that isn't correct: the requestor's request was previously responded to at L332. Validation happens asynchronously from the POST to the challenge, and the requestor learns of its success or failure by polling the authz.

I'm explaining this rather laboriously so that reviewers can let me know if I've misunderstood how ACME works.