### PR TITLE
Fix example acme_requestor JWKS

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -510,10 +510,7 @@ the `acme_requestor` metadata and using the `jwks` metadata parameter.
             "x": "qAOdPQROkHfZY1daGofOmSNQWpYK8c9G2m2Rbkpbd4c",
             "y": "G_7fF-T8n2vONKM15Mzj4KR_shvHBxKGjMosF6FdoPY"
           }
-        ],
-        "iss": "https://requestor.example.com",
-        "sub": "https://requestor.example.com",
-        "iat": 1618410883
+        ]
       }
     }
   }


### PR DESCRIPTION
The example of a JWKS included in an acme_requestor metadata block should not include `iss`, `sub` or `iat`. The protocol text says that the JWK set should be published according to OIDF 5.2.1, which describes metadata keys `signed_jwks_uri`, `jwks_uri` and `jwks`. Only in the first case are `iss`, `sub` or `iat` necessary. Including them when the key set is inline in the metadata is just confusing, because they de facto must have the same `sub` as the enclosing entity configuration.