### PR TITLE
Clarify Ambiguities between OpenID Federation and RFC 5280

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -94,8 +94,9 @@ and technical information related to a specific entity.
 
 This document defines how X.509 certificates associating a given OpenID
 Federation Entity with a key included in that Entity's Configuration can be
-issued by a Certificate Issuer through the ACME protocol to the organizations
-which are part of a federation built on top of OpenID Federation 1.0.
+issued by a X.509 Certification Authority through the ACME protocol to the
+organizations which are part of a federation built on top of OpenID
+Federation 1.0.
 
 --- middle
 
@@ -131,8 +132,8 @@ ACME protocol in the following ways:
   `/.well-known/acme-challenge/{token}` endpoint.
 
 - It defines how the OpenID Federation Subordinate Statements can be used for the
-  publication of the X.509 Certificates, by a X.509 Certificate Authority,
-  that were previously issued with ACME.
+  publication of the X.509 Certificates, by a Certification Authority, that
+  were previously issued with ACME.
 
 - It extends the ACME newOrder resource, as defined in
   {{Section 7.4 of !RFC8555}}, defining a new payload identifier type called
@@ -160,7 +161,7 @@ The terms "Federation Entity", "Trust Anchor", "Entity Configuration",
 "Subordinate Statement", "Trust Mark" and "Trust Chain" used in this
 document are defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
 The term "CSR" used in this document is defined in [RFC2986]. The
-term Certificate Authority used in this document is defined in [RFC5280]. The
+term Certification Authority used in this document is defined in [RFC5280]. The
 terms "ACME Client" and "ACME Server" are defined in [RFC8555].
 
 The specification also defines the following terms:

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -132,8 +132,8 @@ ACME protocol in the following ways:
   `/.well-known/acme-challenge/{token}` endpoint.
 
 - It defines how the OpenID Federation Subordinate Statements can be used for the
-  publication of the X.509 Certificates, by a Trust Anchor or Intermediate, that
-  were previously issued with ACME.
+  publication of the X.509 Certificates, by a X.509 Certificate Authority,
+  that were previously issued with ACME.
 
 - It extends the ACME newOrder resource, as defined in
   {{Section 7.4 of !RFC8555}}, defining a new payload identifier type called
@@ -157,8 +157,8 @@ This specification can be implemented by:
 
 # Terminology
 
-The terms "Federation Entity", "Trust Anchor", "Intermediate", "Entity
-Configuration", "Subordinate Statement", "Trust Mark" and "Trust Chain" used in this
+The terms "Federation Entity", "Trust Anchor", "Entity Configuration",
+"Subordinate Statement", "Trust Mark" and "Trust Chain" used in this
 document are defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
 The term "CSR" used in this document is defined in [RFC2986]. The
 term Certificate Authority used in this document is defined in [RFC5280]. The
@@ -171,7 +171,7 @@ Requestor:
   a web server for hosting its Entity Configuration. It also operates an ACME
   client, extended according to this document.
 
-Issuer:
+Certificate Issuer:
 : A Federation Entity which issues X.509 certificates. It operates a web server
   for hosting its Entity Configuration. It also operates an ACME server,
   extended according to this document.
@@ -684,7 +684,7 @@ and the X.509 Certificate:
 
 # Publication of the Certificates within the Federation
 
-**TBD**, when the Certificate Issuer is the Trust Anchor or Intermediate, the X.509
+**TBD**, when the Certificate Issuer is the Superior Entity, the X.509
 Certificate linked to JWK in the Subordinate
 Statement related to the Requestor, SHOULD be extended with the claim `x5c`,
 containing the issued X.509 Certificate.

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -94,9 +94,8 @@ and technical information related to a specific entity.
 
 This document defines how X.509 certificates associating a given OpenID
 Federation Entity with a key included in that Entity's Configuration can be
-issued by a trust anchor and its intermediates through the ACME protocol to all
-the organizations that are part of a federation built on top of OpenID
-Federation 1.0.
+issued by a Certificate Issuer through the ACME protocol to the organizations
+which are part of a federation built on top of OpenID Federation 1.0.
 
 --- middle
 


### PR DESCRIPTION
Fixes #47.

Earlier reviews we had some stumbles over overloaded uses of Trust Root, Leaf, Issuer, and Intermediate, which all have meanings within OpenID Federation as well as in X.509.

Most of those have already been refactored out, but this PR catches the last ambiguities I could find.

To take them one by one:
-  Replaces the phrase `trust anchor and its intermediates` with `Certification Authority` (prefixed with `X.509` in the _Abstract_, for extra precision), which is a defined term from RFC 5280.
- Updates `certificate authority` to the RFC 5280 term `Certification Authority`.
- Removes the term `Intermediate` from the _Terminology_, as it is no longer used.
- In the Terminology section, changes `Issuer`, which can be confused with a Trust Mark Issuer, to `Certificate Issuer`, which is already how we write it elsewhere in the document.
- Clarifies in the _Publication of the Certificates within the Federation_ section that publication can only be done when the certificate is issued by the `Superior Entity`, not just any Certification Authority.