### PR TITLE
Restrict the OpenID Federation challenge type and identifier to each other.

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -743,10 +743,10 @@ IANA is kindly asked to make the following updates to registries:
 ## Update ACME Identifier Types
 
 IANA is asked to add to the "ACME Identifier Types"
-registry, defined in {{Section 9.7.7 of !RFC8555}} a label "openid-federation" and reference this document.
+registry, defined in {{Section 9.7.7 of !RFC8555}}, a label "openid-federation" and reference {{identifier-type}} in this document.
 
-IANA is also asked to to the "ACME Validation Methods"
-registry, defined in {{Section 9.7.8 of !RFC8555}} add a label "openid-federation-01" and reference this document.
+IANA is also asked to add to the "ACME Validation Methods"
+registry, defined in {{Section 9.7.8 of !RFC8555}}, a label "openid-federation-01" and reference {{challenge-type}} in this document.
 
 ## Assign X.509 PKIX Other Name
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -586,7 +586,7 @@ token (required, string):  A random value that uniquely identifies the
    }
 ~~~~
 
-The `openid-federation-01` challenge MUST NOT be used to issue certificates
+The `openid-federation-01` challenge MUST NOT be used to issue X.509 Certificates
 for any identifiers except `openid-federation` identifiers.
 
 The `openid-federation` identifier MUST NOT be validated except by the

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -516,13 +516,16 @@ The Issuer MUST only use the Requestor's `acme_requestor` to validate an ACME
 challenge. Therefore, after completing the challenge, the Requestor MAY remove
 the `acme_requestor` metadata from its Entity Configuration.
 
+## OpenID Federation Identifier {#identifier-type}
+
+This document defines a new OpenID Federation identifier, `openid-federation`,
+whose value is the `sub` parameter of the requestor's Entity Configuration,
+as defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
+
 ## newOrder Request
 
 The Requestor begins certificate issuance by sending a HTTP POST request to the
-Issuer's `newOrder` resource, as specified in {{Section 7.4 of !RFC8555}}. However,
-the request payload uses a new identifier `openid-federation`, whose value is
-the `sub` parameter of the requestor's Entity Configuration, as defined in
-{{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
+Issuer's `newOrder` resource, as specified in {{Section 7.4 of !RFC8555}}.
 
 A non-normative example of an ACME newOrder request:
 
@@ -582,6 +585,12 @@ token (required, string):  A random value that uniquely identifies the
      "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
    }
 ~~~~
+
+The `openid-federation-01` challenge MUST NOT be used to issue certificates
+for any identifiers except `openid-federation` identifiers.
+
+The `openid-federation` identifier MUST NOT be validated except by the
+`openid-federation-01` challenge.
 
 The Requestor responds with an object with the following format:
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -518,7 +518,7 @@ the `acme_requestor` metadata from its Entity Configuration.
 
 ## OpenID Federation Identifier {#identifier-type}
 
-This document defines a new OpenID Federation identifier, `openid-federation`,
+This document defines a new ACME identifier type for OpenID Federation entities, `openid-federation`,
 whose value is the `sub` parameter of the requestor's Entity Configuration,
 as defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
 


### PR DESCRIPTION
Fixes #59.

This pulls the definition of `openid-federation`'s Identifier Type into its own heading, moving it slightly up the page, to make it more clear it's there and happening (like with https://datatracker.ietf.org/doc/html/draft-ietf-acme-onion-07#name-identifier and https://datatracker.ietf.org/doc/html/rfc8738#name-ip-identifier).

Then it adds the necessary `MUST NOT` conditions on usage, taking some inspiration from https://datatracker.ietf.org/doc/html/rfc8738#section-7 and https://datatracker.ietf.org/doc/html/draft-ietf-acme-onion-07#section-3.1.1.