### PR TITLE
Loosen certificate profile

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -666,15 +666,15 @@ A non-normative example for the challenge object post-validation:
 ### CSR and Certificate Requirements
 
 When using this challenge type, both the certificate signing request (CSR)
-and the X.509 Certificate:
+and the X.509 Certificate MUST include a public key corresponding to
+the key used to satisfy the challenge.
 
-* MUST include a public key corresponding to
-  the key used to satisfy the challenge.
-
-* MUST include no Common Name, and must include
-  a single Subject Alternative Name value corresponding to an `otherName` with a `type-id` of `id-on-OpenIdFederationEntityId`, containing an Octet String value corresponding to a UTF-8
-  encoding of the Requestor's Entity ID, that is, the value of the `sub` claim
-  of the Requestor's Entity Configuration.
+Depending on the Certificate Issuer's X.509 certificate profile, the CSR and
+X.509 Certificate MAY associate the certificate to the Federation Entity by
+including a Subject Alternative Name value corresponding to an `otherName` with
+a `type-id` of `id-on-OpenIdFederationEntityId`, containing an Octet String
+value corresponding to a UTF-8 encoding of the Entity ID in the
+`openid-federation` identifier in the `newOrder` request.
 
 ~~~~
    id-on-OpenIdFederationEntityId OBJECT IDENTIFIER ::= { id-on XXX }

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -661,9 +661,9 @@ When using this challenge type, both the certificate signing request (CSR)
 and the X.509 Certificate MUST include a public key corresponding to
 the key used to satisfy the challenge.
 
-Depending on the Certificate Issuer's X.509 certificate profile, the CSR and
-X.509 Certificate MAY associate the certificate to the Federation Entity by
-including the Entity ID in the certificate.
+Depending on the Certificate Issuer's X.509 Certificate profile, the CSR and
+X.509 Certificate MAY associate the X.509 Certificate to the Federation Entity by
+including the Entity ID in the X.509 Certificate.
 To do so, the Issuer includes a Subject Alternative Name extension
 containing an `otherName` with
 a `type-id` of `id-on-OpenIdFederationEntityId`.

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -552,11 +552,6 @@ A non-normative example of an ACME newOrder request:
    }
 ~~~~
 
-The maximum length of the JSON array contained in the identifiers parameter
-MUST be 1, since there cannot be more than a single URI corresponding to a
-Federation Entity.
-
-
 ## OpenID Federation Challenge Type {#challenge-type}
 
 The OpenID Federation challenge type allows a Requestor to prove control of a
@@ -630,11 +625,8 @@ On receiving a response, the Certificate Issuer retrieves the public keys associ
 the given entity (possibly performing Federation Entity Discovery to do so),
 then:
 
-* Verifies that the requested `openid-federation` value matches the `sub`
-  parameter of the Requestor's Entity Configuration. Since the Entity
-  Configuration MUST contain at most one Entity Identifier, this effectively
-  means this challenge type works with requests for a single Federation Entity
-  only.
+* Verifies that the requested `openid-federation` identifier value matches the `sub`
+  parameter of the Requestor's Entity Configuration.
 
 * Verifies that the `sig` field of the payload includes a valid JWT over the
   key authorization, signed with one of the keys published in the Requestor's

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -663,10 +663,14 @@ the key used to satisfy the challenge.
 
 Depending on the Certificate Issuer's X.509 certificate profile, the CSR and
 X.509 Certificate MAY associate the certificate to the Federation Entity by
-including a Subject Alternative Name value corresponding to an `otherName` with
-a `type-id` of `id-on-OpenIdFederationEntityId`, containing an Octet String
-value corresponding to a UTF-8 encoding of the Entity ID in the
-`openid-federation` identifier in the `newOrder` request.
+including the Entity ID in the certificate.
+To do so, the Issuer includes a Subject Alternative Name extension
+containing an `otherName` with
+a `type-id` of `id-on-OpenIdFederationEntityId`.
+The value of the name is an Octet String
+containing the UTF-8 encoding of the Entity ID
+(i.e., the URI in the corresponding `openid-federation` identifier
+from the `newOrder` request).
 
 ~~~~
    id-on-OpenIdFederationEntityId OBJECT IDENTIFIER ::= { id-on XXX }


### PR DESCRIPTION
This relaxes some restrictions on certificates. Putting the entity ID in a subject alternative name is now optional. The requirement to have only one identifier per order is deleted in two places. Closes #54 and #38.