### PR TITLE
Rephrase description of trust chain

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -600,9 +600,9 @@ sig (required, string):  the compact JSON serialization (as described in
     The JWS MUST include a `kid` header parameter corresponding to the key used
     to sign the key authorization and a `typ` header parameter set to
     "signed-acme-challenge+jwt".
-trust_chain (optional, array of string):  an array of base64url-encoded bytes
-    containing a signed JWT and representing the Trust Chain of the Requestor,
-    See {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}.
+trust_chain (optional, array of string):  an array of strings containing signed JWTs,
+    representing the Trust Chain of the Requestor,
+    see {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}.
     The Requestor SHOULD use a Trust Anchor it
     has in common with the ACME server. It is RECOMMENDED that the Requestor
     includes this field; otherwise, the ACME server MUST start Federation Entity


### PR DESCRIPTION
The strings in the `trust_chain` array are not base64url-encoded data, but compact form JWTs.