### PR TITLE
Revise publication to rely on Certificate Transparency

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -673,10 +673,10 @@ from the `newOrder` request).
 
 # Publication of the Certificates within the Federation
 
-When the Certificate Issuer is the Superior Entity, the X.509
-Certificate linked to JWK in the Subordinate
-Statement related to the Requestor, SHOULD be extended with the claim `x5c`,
-containing the issued X.509 Certificate.
+All X.509 Certificates issued SHOULD be published to one or more Certificate
+Transparency logs {{!RFC9162}}. Selection of those logs, their versions, and
+embedding or discovery of Signed Certificate Timestamps, are policy decisions
+and are out of scope for this document.
 
 # Certificate Lifecycle and Revocation
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -678,6 +678,10 @@ Transparency logs {{!RFC9162}}. Selection of those logs, their versions, and
 embedding or discovery of Signed Certificate Timestamps, are policy decisions
 and are out of scope for this document.
 
+Federation Immediate Superior Entities having issued X.509 Certificates pertaining to one or more Federation Entity Keys in control of their Subordinates MAY evidence this information by including in each JWK contained within the Subordinate Statement the member `x5c`. When this happens, it's up to the implementation to decide if the `x5c` should contain the entire X.509 Certificate Chain, from the CA to the Subordinate, or only the X.509 Certificate about the Subordinate. 
+
+Please note that multiple Immediate Superior Entities above the Subordinate Statement Issuer (such as other Intermediates or Trust Anchors) may have produced cryptographically verifiable X.509 Certificates about the Subordinate Statement Issuer, making the single `x5c` verifiable using more than a single X.509 Certificate about its issuer, signed by more than a single Immediate Superior. This is similar to the federation Trust Chain, where a single Entity Statement can be linked to one or more Subordinate Statements.
+
 # Certificate Lifecycle and Revocation
 
 The identity of the Requestor is verified through proof of possession of a

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -678,9 +678,13 @@ Transparency logs {{!RFC9162}}. Selection of those logs, their versions, and
 embedding or discovery of Signed Certificate Timestamps, are policy decisions
 and are out of scope for this document.
 
-Federation Immediate Superior Entities having issued X.509 Certificates pertaining to one or more Federation Entity Keys in control of their Subordinates MAY evidence this information by including in each JWK contained within the Subordinate Statement the member `x5c`. When this happens, it's up to the implementation to decide if the `x5c` should contain the entire X.509 Certificate Chain, from the CA to the Subordinate, or only the X.509 Certificate about the Subordinate. 
-
-Please note that multiple Immediate Superior Entities above the Subordinate Statement Issuer (such as other Intermediates or Trust Anchors) may have produced cryptographically verifiable X.509 Certificates about the Subordinate Statement Issuer, making the single `x5c` verifiable using more than a single X.509 Certificate about its issuer, signed by more than a single Immediate Superior. This is similar to the federation Trust Chain, where a single Entity Statement can be linked to one or more Subordinate Statements.
+The X.509 Certificates issued by Federation Immediate Superior Entities
+pertaining to one or more Federation Entity Keys in control of their
+Subordinates MAY publish this information by including the `x5c` member
+in each JWK contained within the matching Subordinate Statement. The contents
+of the published `x5c` member, including whether it contains a full or
+partial Trust Chain, and if so, to what Trust Anchor, are policy decisions
+out of scope for this document.
 
 # Certificate Lifecycle and Revocation
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -157,8 +157,9 @@ This specification can be implemented by:
 # Terminology
 
 The terms "Federation Entity", "Trust Anchor", "Entity Configuration",
-"Subordinate Statement", "Superior Entity", "Trust Mark" and "Trust Chain"
-used in this document are defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
+"Subordinate Statement", "Superior Entity", "Immediate Superior Entity",
+"Federation Entity Keys", "Trust Mark" and "Trust Chain" used in this
+document are defined in {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2"}.
 The term "CSR" used in this document is defined in [RFC2986]. The
 term Certification Authority used in this document is defined in [RFC5280]. The
 terms "ACME Client" and "ACME Server" are defined in [RFC8555].
@@ -678,7 +679,7 @@ Transparency logs {{!RFC9162}}. Selection of those logs, their versions, and
 embedding or discovery of Signed Certificate Timestamps, are policy decisions
 and are out of scope for this document.
 
-The X.509 Certificates issued by Federation Immediate Superior Entities
+The X.509 Certificates issued by federation Immediate Superior Entities
 pertaining to one or more Federation Entity Keys in control of their
 Subordinates MAY publish this information by including the `x5c` member
 in each JWK contained within the matching Subordinate Statement. The contents


### PR DESCRIPTION
This moves responsibility for publication of certificates from the OIDFed hierarchy to RFC6962/RFC9162 certificate transparency logs, and otherwise marks it as out-of-scope.

I am hoping this is unambiguous that how a Certificate Issuer does it is for policy, to include whether they submit pre-certificates or final certificates, or if they embed SCTs or transmit them some other way, or even use CTv1 vs CTv2.

Fixes #65.