### PR TITLE
Allow issuer to provide TAs to requestor

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -564,12 +564,24 @@ token (required, string):  A random value that uniquely identifies the
     {{Section 5 of !RFC4648}}. Trailing '=' padding characters MUST be stripped.
     See {{!RFC4086}} for additional information on randomness requirements.
 
+trust_anchors (optional, array of string):  An array of strings containing
+    Entity Identifiers of the Issuer's trust anchors. When solving the
+    challenge, the Requestor can construct a trust chain from itself to one of
+    these trust anchors. It is RECOMMENDED that the Issuer includes this field
+    to make it easier for the Requestor to construct a trust chain.
+
+A non-normative example of a challenge with `trust_anchors` specified:
+
 ~~~~
    {
      "type": "openid-federation-01",
      "url": "https://issuer.example.com/acme/chall/prV_B7yEyA4",
      "status": "pending",
-     "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+     "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
+     "trust_anchors": [
+       "https://trust-anchor-1.example.com",
+       "https://trust-anchor-2.example.com"
+     ]
    }
 ~~~~
 
@@ -592,13 +604,14 @@ sig (required, string):  the compact JSON serialization (as described in
     The JWS MUST include a `kid` header parameter corresponding to the key used
     to sign the key authorization and a `typ` header parameter set to
     "signed-acme-challenge+jwt".
-trust_chain (optional, array of string):  an array of strings containing signed JWTs,
-    representing the Trust Chain of the Requestor,
-    see {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}.
-    The Requestor SHOULD use a Trust Anchor it
-    has in common with the ACME server. It is RECOMMENDED that the Requestor
-    includes this field; otherwise, the ACME server MUST start Federation Entity
-    Discovery to obtain the Trust Chain related to the Requestor.
+
+trust_chain (optional, array of string):  an array of strings containing signed
+    JWTs, representing a Trust Chain from the Requestor to one of the Issuer's
+    trust anchors (see
+    {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}). It is RECOMMENDED
+    that the Requestor includes this field; otherwise, the ACME server MUST
+    start Federation Entity Discovery to obtain the Trust Chain related to the
+    Requestor.
 
 A non-normative example for an authorization with `trust_chain` specified:
 


### PR DESCRIPTION
When solving an `openid-federation-01` challenge, the requestor may provide a trust chain from itself to a trust anchor trusted by the issuer, to save the issuer the trouble of doing a resolve. However it's not clear how the requestor is supposed to know what TAs the issuer trusts.

This commit adds an optional field `trust_anchors` to the challenge object. The requestor can use that to construct a trust chain that the issuer will accept.

Additionally, this removes the sentence "The Requestor SHOULD use a Trust Anchor it has in common with the ACME server."

First, I don't think it's the right requirement. What matters is that (1) the trust anchor be trusted by the issuer and (2) there be some path from the requestor to the trust anchor. Those can be true even if the requestor doesn't trust the TA! To illustrate:

```
trust_anchor_1           trust_anchor_2
     |________________________|
                  |
            intermediate
                  |
     +------------+-----------+
     |                        |
  issuer                 requestor
```

If issuer trusts trust_anchor_1 but not _2, and requestor trusts trust_anchor_2 but not _1, then trust_anchor_1->intermediate->requestor is a valid trust chain for solving a challenge even if requestor wouldn't trust it.

Second, it makes more sense as a MUST than a SHOULD. I rewrote it to make it explicit that the trust chain must end in one of the issuer's trust anchors.

Resolves #79