### PR TITLE
Clarify trust chain metadata validation

### DIFF
--- a/diagrams/plantuml
+++ b/diagrams/plantuml
@@ -14,12 +14,12 @@ A -->> RC: Challenge validation beginning
 
 A ->> RF: GET /.well-known/openid-federation
 RF -->> A: Requestor's Entity Configuration
-A ->> A: Check Entity Configuration sub matches\nEntity identifier in the order
-A ->> A: Check challenge sig is signed\nwith key in Entity Configuration
 opt If requestor did not provide Trust Chain
   A <<->> F: Determine Trust Chain\nfrom Issuer's Trust Anchor to Requestor\n(OpenID Federation Discovery)
 end
 A ->> A: Evaluate trust chain
+A ->> A: Check Entity Configuration sub matches\nEntity identifier in the order
+A ->> A: Check challenge sig is signed\nwith key in Entity Configuration
 
 loop Poll until authz status is "valid" or "invalid"
 RC ->> A: POST-as-GET /acme/authz/[authz-id]

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -564,13 +564,13 @@ token (required, string):  A random value that uniquely identifies the
     {{Section 5 of !RFC4648}}. Trailing '=' padding characters MUST be stripped.
     See {{!RFC4086}} for additional information on randomness requirements.
 
-trust_anchors (optional, array of string):  An array of strings containing
+trustAnchors (optional, array of string):  An array of strings containing
     Entity Identifiers of the Issuer's trust anchors. When solving the
     challenge, the Requestor can construct a trust chain from itself to one of
     these trust anchors. It is RECOMMENDED that the Issuer includes this field
     to make it easier for the Requestor to construct a trust chain.
 
-A non-normative example of a challenge with `trust_anchors` specified:
+A non-normative example of a challenge with `trustAnchors` specified:
 
 ~~~~
    {
@@ -578,7 +578,7 @@ A non-normative example of a challenge with `trust_anchors` specified:
      "url": "https://issuer.example.com/acme/chall/prV_B7yEyA4",
      "status": "pending",
      "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
-     "trust_anchors": [
+     "trustAnchors": [
        "https://trust-anchor-1.example.com",
        "https://trust-anchor-2.example.com"
      ]

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -564,12 +564,24 @@ token (required, string):  A random value that uniquely identifies the
     {{Section 5 of !RFC4648}}. Trailing '=' padding characters MUST be stripped.
     See {{!RFC4086}} for additional information on randomness requirements.
 
+trust_anchors (optional, array of string):  An array of strings containing
+    Entity Identifiers of the Issuer's trust anchors. When solving the
+    challenge, the Requestor can construct a trust chain from itself to one of
+    these trust anchors. It is RECOMMENDED that the Issuer includes this field
+    to make it easier for the Requestor to construct a trust chain.
+
+A non-normative example of a challenge with `trust_anchors` specified:
+
 ~~~~
    {
      "type": "openid-federation-01",
      "url": "https://issuer.example.com/acme/chall/prV_B7yEyA4",
      "status": "pending",
-     "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+     "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
+     "trust_anchors": [
+       "https://trust-anchor-1.example.com",
+       "https://trust-anchor-2.example.com"
+     ]
    }
 ~~~~
 
@@ -592,13 +604,14 @@ sig (required, string):  the compact JSON serialization (as described in
     The JWS MUST include a `kid` header parameter corresponding to the key used
     to sign the key authorization and a `typ` header parameter set to
     "signed-acme-challenge+jwt".
-trust_chain (optional, array of string):  an array of strings containing signed JWTs,
-    representing the Trust Chain of the Requestor,
-    see {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}.
-    The Requestor SHOULD use a Trust Anchor it
-    has in common with the ACME server. It is RECOMMENDED that the Requestor
-    includes this field; otherwise, the ACME server MUST start Federation Entity
-    Discovery to obtain the Trust Chain related to the Requestor.
+
+trust_chain (optional, array of string):  an array of strings containing signed
+    JWTs, representing a Trust Chain from the Requestor to one of the Issuer's
+    trust anchors (see
+    {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}). It is RECOMMENDED
+    that the Requestor includes this field; otherwise, the ACME server MUST
+    start Federation Entity Discovery to obtain the Trust Chain related to the
+    Requestor.
 
 A non-normative example for an authorization with `trust_chain` specified:
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -566,9 +566,9 @@ token (required, string):  A random value that uniquely identifies the
 
 trustAnchors (optional, array of string):  An array of strings containing
     Entity Identifiers of the Issuer's trust anchors. When solving the
-    challenge, the Requestor can construct a trust chain from itself to one of
-    these trust anchors. It is RECOMMENDED that the Issuer includes this field
-    to make it easier for the Requestor to construct a trust chain.
+    challenge, the Requestor can construct a Trust Chain from itself to one of
+    these Trust Anchors. It is RECOMMENDED that the Issuer includes this field
+    to make it easier for the Requestor to construct a Trust Chain.
 
 A non-normative example of a challenge with `trustAnchors` specified:
 
@@ -607,11 +607,15 @@ sig (required, string):  the compact JSON serialization (as described in
 
 trustChain (optional, array of string):  an array of strings containing signed
     JWTs, representing a Trust Chain from the Requestor to one of the Issuer's
-    trust anchors (see
-    {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}). It is RECOMMENDED
-    that the Requestor includes this field; otherwise, the ACME server MUST
-    start Federation Entity Discovery to obtain the Trust Chain related to the
-    Requestor.
+    Trust Anchors (see {{Section 4 of OPENID-FED}}{: relative="#section-4"}).
+    It is RECOMMENDED that the Requestor includes this field; otherwise the ACME
+    server MUST start Federation Entity Discovery to obtain the Trust Chain
+    related to the Requestor.
+    If the Requestor cannot construct a Trust Chain to one of the Trust Anchors
+    indicated by the Issuer, or if no Trust Anchors were indicated, it MAY use
+    some other Trust Anchor that it believes the Issuer trusts.
+    If the Requestor cannot construct a Trust Chain to any Trust Anchor, it MAY
+    omit the `trustChain` field from the challenge response.
 
 A non-normative example for an authorization with `trustChain` specified:
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -605,7 +605,7 @@ sig (required, string):  the compact JSON serialization (as described in
     to sign the key authorization and a `typ` header parameter set to
     "signed-acme-challenge+jwt".
 
-trust_chain (optional, array of string):  an array of strings containing signed
+trustChain (optional, array of string):  an array of strings containing signed
     JWTs, representing a Trust Chain from the Requestor to one of the Issuer's
     trust anchors (see
     {{Section 4.3 of OPENID-FED}}{: relative="#section-4.3"}). It is RECOMMENDED
@@ -613,7 +613,7 @@ trust_chain (optional, array of string):  an array of strings containing signed
     start Federation Entity Discovery to obtain the Trust Chain related to the
     Requestor.
 
-A non-normative example for an authorization with `trust_chain` specified:
+A non-normative example for an authorization with `trustChain` specified:
 
 ~~~~
    POST /acme/chall/prV_B7yEyA4
@@ -629,7 +629,7 @@ A non-normative example for an authorization with `trust_chain` specified:
      }),
      "payload": base64url({
       "sig": "wQAvHlPV1tVxRW0vZUa4BQ...",
-      "trust_chain": ["eyJhbGciOiJFU...", "eyJhbGci..."]
+      "trustChain": ["eyJhbGciOiJFU...", "eyJhbGci..."]
      }),
      "signature": "Q1bURgJoEslbD1c5...3pYdSMLio57mQNN4"
    }

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -306,8 +306,8 @@ ACME account with the Issuer.
         |                  |<- - - - - - - - - - - - - - - - -                           |
         |                  |                                 |                           |
         |                  ----.                             |                           |
-        |                      | Sign challenge token        |                           |
-        |                      | with private key            |                           |
+        |                  |   | Sign challenge token        |                           |
+        |                  |   | with private key            |                           |
         |                  <---'                             |                           |
         |                  |                                 |                           |
         |                  | POST /acme/chall/[chall-id]     |                           |
@@ -326,6 +326,20 @@ ACME account with the Issuer.
         |           Requestor's Entity Configuration         |                           |
         | - - -  - - - - - - - - - - - - - - - - - - - - - - >                           |
         |                  |                                 |                           |
+        |                  |           ______________________________________________________
+        |                  |           ! OPT  /  If requestor didn't provide Trust Chain |  !
+        |                  |           !_____/               |                           |  !
+        |                  |           !                     |  Determine Trust Chain    |  !
+        |                  |           !                     |  from Issuer's            |  !
+        |                  |           !                     |  Trust Anchor to Requestor|  !
+        |                  |           !                     |  (Federation Discovery)   |  !
+        |                  |           !                     | <------------------------>|  !
+        |                  |           !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+        |                  |                                 |                           |
+        |                  |                                 |----.                      |
+        |                  |                                 |    | Evaluate Trust Chain |
+        |                  |                                 |<---'                      |
+        |                  |                                 |                           |
         |                  |                                 |----.                      |
         |                  |                                 |    | Check                |
         |                  |                                 |    | Entity Configuration |
@@ -339,22 +353,6 @@ ACME account with the Issuer.
         |                  |                                 |    | sig is signed        |
         |                  |                                 |    | with key in          |
         |                  |                                 |<---' Entity Configuration |
-        |                  |                                 |                           |
-        |                  |                                 |                           |
-        |                  |                                 |                           |
-        |                  |           ______________________________________________________
-        |                  |           ! OPT  /  If requestor didn't provide Trust Chain |  !
-        |                  |           !_____/               |                           |  !
-        |                  |           !                     |  Determine Trust Chain    |  !
-        |                  |           !                     |  from Issuer's            |  !
-        |                  |           !                     |  Trust Anchor to Requestor|  !
-        |                  |           !                     |  (Federation Discovery)   |  !
-        |                  |           !                     | <------------------------>|  !
-        |                  |           !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-        |                  |                                 |                           |
-        |                  |                                 |----.                      |
-        |                  |                                 |    | Evaluate trust chain |
-        |                  |                                 |<---'                      |
         |                  |                                 |                           |
         |  _________________________________________________________________________     |
         |  ! LOOP  /  Poll until authz status                |                      !    |
@@ -550,9 +548,9 @@ A non-normative example of an ACME newOrder request:
 ## OpenID Federation Challenge Type {#challenge-type}
 
 The OpenID Federation challenge type allows a Requestor to prove control of a
-Federation Entity using the trust evaluation mechanism
-provided by {{OPENID-FED}}. The Requestor demonstrates control of a
-cryptographic public key published in its OpenID Federation Entity Configuration.
+Federation Entity using the trust evaluation mechanism provided by
+{{OPENID-FED}}. The Requestor demonstrates control of a cryptographic public key
+published in its OpenID Federation Entity Configuration.
 
 The openid-federation-01 ACME challenge object has the following format:
 
@@ -608,9 +606,11 @@ sig (required, string):  the compact JSON serialization (as described in
 trustChain (optional, array of string):  an array of strings containing signed
     JWTs, representing a Trust Chain from the Requestor to one of the Issuer's
     Trust Anchors (see {{Section 4 of OPENID-FED}}{: relative="#section-4"}).
-    It is RECOMMENDED that the Requestor includes this field; otherwise the ACME
-    server MUST start Federation Entity Discovery to obtain the Trust Chain
-    related to the Requestor.
+    The Entity Configuration of the Trust Chain subject MUST contain
+    `acme_requestor` metadata that is valid under the Trust Chain's resolved
+    metadata policy ({{Section 6.1 of OPENID-FED}}{: relative="#section-6.1"})
+    and which contains the key used to compute `sig`.
+    It is RECOMMENDED that the Requestor includes this field.
     If the Requestor cannot construct a Trust Chain to one of the Trust Anchors
     indicated by the Issuer, or if no Trust Anchors were indicated, it MAY use
     some other Trust Anchor that it believes the Issuer trusts.
@@ -639,24 +639,31 @@ A non-normative example for an authorization with `trustChain` specified:
    }
 ~~~~
 
-On receiving a challenge response, the Certificate Issuer retrieves the public keys associated with
-the given entity (possibly performing Federation Entity Discovery to do so),
-then:
+On receiving a challenge response, the Certificate Issuer verifies that the
+Requestor is trusted. If the Requestor did not provide a `trustChain`, the
+Issuer MUST perform Federation Entity Discovery to obtain a Trust Chain for the
+Requestor.
 
-* Verifies that the requested `openid-federation` identifier value matches the `sub`
+Once it has obtained a Trust Chain, the Issuer verifies:
+
+* That the Requestor's `acme_requestor` metadata is valid under the Trust
+  Chain's resolved metadata policy
+  ({{Section 6.1 of OPENID-FED}}}: relative="#section-6.1"}).
+
+* That the requested `openid-federation` identifier value matches the `sub`
   parameter of the Requestor's Entity Configuration.
 
-* Verifies that the `sig` field of the payload includes a valid JWT over the
-  key authorization, signed with one of the keys published in the Requestor's
-  `acme_requestor` metadata in its Entity Configuration, as specified in
-  {{requestor-metadata}}. The Issuer MUST only consider the key
-  whose `kid` matches the `kid` claim in the Requestor's challenge response.
-  The Issuer also MUST only consider keys published in the Requestor's
+* That the `sig` field of the payload is a compact JSON serialization of a JWS
+  signing the key authorization, signed with one of the keys published in the
+  Requestor's `acme_requestor` metadata in its Entity Configuration, as
+  specified in {{requestor-metadata}}. The Issuer MUST only consider the key
+  whose `kid` matches the `kid` claim in the Requestor's challenge response. The
+  Issuer also MUST only consider keys published in the Requestor's
   `acme_requestor` metadata.
 
 If all of the above verifications succeed, then the validation is successful.
-Otherwise, it has failed. In either case, the Certificate Issuer responds according to
-{{Section 7.5.1 of !RFC8555}}.
+Otherwise, it has failed. In either case, the Certificate Issuer responds
+according to {{Section 7.5.1 of !RFC8555}}.
 
 A non-normative example for the challenge object post-validation:
 


### PR DESCRIPTION
# Stacked on #80 

- Fix sequence diagram: trust is established before verifying key authorizaton
- Clarify that the `acme_requestor` metadata has to be valid under Federation policy
