### PR TITLE
Change the definition of acme_issuer to be the URL to the ACME directory

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -418,7 +418,7 @@ respective Entity Configurations.
 ### Issuer Metadata
 
 The Issuer MUST publish its Entity Configuration including the `acme_issuer`
-metadata within it. The body of the `acme_issuer` metadata is the ACME
+metadata within it. The `acme_issuer` is the URL of the ACME
 Directory, as defined in {{Section 7.1.1 of !RFC8555}}.
 
 Requestors MUST use the ACME Directory provided in the Issuer's Entity
@@ -446,16 +446,7 @@ the `acme_issuer` metadata:
     ]
   },
   "metadata": {
-    "acme_issuer": {
-      "newNonce": "https://issuer.example.com/acme/new-nonce",
-      "newOrder": "https://issuer.example.com/acme/new-order",
-      "revokeCert": "https://issuer.example.com/acme/revoke-cert",
-      "meta": {
-        "termsOfService": "https://issuer.example.com/acme/terms/2017-5-30",
-        "website": "https://www.issuer.example.com/",
-        "externalAccountRequired": false
-      }
-    }
+    "acme_issuer": "https://issuer.example.com/acme/directory"
   }
 }
 ~~~~


### PR DESCRIPTION
As described in Issue #60, this PR removes the duplication of ACME Directory information from the issuer's Entity Configuration, favoring instead the URL to the ACME Directory as defined in RFC 8555.

Doing this removes the ability to identify changes in the ACME Directory information via the Entity Configuration, in exchange for simplification across the stack for clients and issuers. It's still possible to identify changes via the Directory directly. 

A point-by-point analysis of the consequences of this change is posted in https://github.com/peppelinux/draft-demarco-acme-openid-federation/issues/60#issuecomment-2688694461. Further commentary is welcome.

@peppelinux @selfissued

Fixes #60. 