### PR TITLE
Update OpenID Federation reference to draft 44

### DIFF
--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -119,9 +119,9 @@ trust framework. OpenID Federation 1.0 allows each participant to recognize
 other participants using a trust evaluation mechanism, with RESTful services and
 cryptographic materials.
 
-Federation members declare what kind Entities they are using a basic OpenID
-Federation component called an Entity Configuration, a signed JSON Web Token
-published in a well-known resource. This document defines new OpenID Federation
+Federation members declare what kind of Entities they are using a basic OpenID
+Federation component called an Entity Configuration, a signed JSON Web Token.
+This document defines new OpenID Federation
 Entity Types for certificate Requestors and Issuers, facilitating automated
 discovery of an issuer's ACME API.
 
@@ -182,14 +182,12 @@ Entity Identifier:
   {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2-3.4"}.
 
 Requestor:
-: A Federation Entity which wants to request X.509 Certificates. It operates
-  a web server for hosting its Entity Configuration. It also operates an ACME
-  client, extended according to this document.
+: A Federation Entity which wants to request X.509 Certificates. It operates an
+  ACME client, extended according to this document.
 
 Certificate Issuer (or Issuer):
-: A Federation Entity which issues X.509 Certificates. It operates a web server
-  for hosting its Entity Configuration. It also operates an ACME server,
-  extended according to this document.
+: A Federation Entity which issues X.509 Certificates. It operates an ACME
+  server, extended according to this document.
 
 # Conventions and Definitions
 

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -51,9 +51,9 @@ contributor:
 
 normative:
   OPENID-FED:
-    title: "OpenID Federation 1.0 - draft 43"
-    target: https://openid.net/specs/openid-federation-1_0-43.html
-    date: 2025-06-02
+    title: "OpenID Federation 1.0 - draft 44"
+    target: https://openid.net/specs/openid-federation-1_0-44.html
+    date: 2025-10-15
     author:
       -
         ins: R. Hedberg

--- a/draft-demarco-acme-openid-federation.md
+++ b/draft-demarco-acme-openid-federation.md
@@ -178,7 +178,8 @@ ACME Identifier:
   client proves control of to the ACME server.
 
 Entity Identifier:
-: A URL that uniquely identifies an Entity in OpenID Federation, as defined in
+: A globally unique string that uniquely identifies an Entity in OpenID
+  Federation, as defined in
   {{Section 1.2 of OPENID-FED}}{: relative="#section-1.2-3.4"}.
 
 Requestor:


### PR DESCRIPTION
This updates our reference to OpenID Federation 1.0 to the latest draft, and makes some related updates. "Entity Identifier" is now defined to be a globally unique string, not necessarily a URL. The Entity Configuration is no longer guaranteed to be served via HTTPS at the URL obtained from concatenating the Entity Identifier with a well-known path component, so I removed a few references to the Entity Configuration being published in this manner for generality. Related to #114.